### PR TITLE
ngram WFST SetOpt() fix

### DIFF
--- a/LanguageModelDecoder/runtime/core/decoder/brain_speech_decoder.cc
+++ b/LanguageModelDecoder/runtime/core/decoder/brain_speech_decoder.cc
@@ -29,7 +29,6 @@ BrainSpeechDecoder::BrainSpeechDecoder(
 }
 
 void BrainSpeechDecoder::SetOpt(const std::shared_ptr<DecodeOptions> opts) {
-  opts_ = opts;
   acoustic_scale_ = opts->ctc_wfst_search_opts.acoustic_scale;
   (static_cast<CtcWfstBeamSearch*>(searcher_.get()))->SetOpt(opts->ctc_wfst_search_opts);
 }


### PR DESCRIPTION
There is already a built-in `SetOpt()` function that is meant to allow you to change the WFST hyperparameters (e.g., acoustic scale) without restarting the language model, but the current implementation does not work, and causes the WFST to return empty predictions after this function is called.

Removing this single line from `brain_speech_decoder.cc` makes the `SetOpt()` function work as intended.